### PR TITLE
Folderについて、orchestratorConfigSaved に変更があったら、という処理をTrueになったら、に変更  etc.

### DIFF
--- a/sample_web/src/components/Folders.vue
+++ b/sample_web/src/components/Folders.vue
@@ -44,7 +44,9 @@ export default {
   watch: {
     orchestratorConfigSaved: {
       handler: function() {
-        this.executeAPI()
+        if (this.orchestratorConfigSaved) {
+          this.executeAPI()
+        }
       },
       deep: true,
     },

--- a/sample_web/src/modules/AppStore.js
+++ b/sample_web/src/modules/AppStore.js
@@ -29,6 +29,9 @@ export default {
     },
   },
   actions: {
+    orchestratorConfigNotSaved(context) {
+      context.commit('orchestratorConfigSaved', false)
+    },
     saveEnterpriseConfig(context, payload) {
       context.commit('enterpriseConfig', payload.config)
       context.commit('orchestratorConfigSaved', true)

--- a/sample_web/src/views/Licenses.vue
+++ b/sample_web/src/views/Licenses.vue
@@ -354,8 +354,13 @@ export default {
     },
 
     id2RobotName(robotId) {
+      // robotId のある列について
       if (robotId) {
-        return this.robots.find(robot => robot.Id === robotId).Name
+        // 選択されたフォルダのロボットが取得できている場合
+        if (this.robots) {
+          const robot = this.robots.find(robot => robot.Id === robotId)
+          return robot ? robot.Name : '別フォルダのロボット' // そのフォルダではないロボットの場合もある
+        }
       }
       return ''
     },

--- a/sample_web/src/views/Settings.vue
+++ b/sample_web/src/views/Settings.vue
@@ -154,6 +154,7 @@ export default {
   },
   methods: {
     save(selectedRobotModeFlag) {
+      this.$store.dispatch('appStore/orchestratorConfigNotSaved')
       saveConfig(this, selectedRobotModeFlag)
     },
 


### PR DESCRIPTION
Folderについて、orchestratorConfigSaved に変更があったら、という処理をTrueになったら、に変更
orchestratorConfigSaved をfalseに戻すactionをVuexへ追加し、設定の保存前に一度それを呼び出すようにした。(結果、orchestratorConfigSaved がtrueにchangeする)

ライセンス状態について、別フォルダのロボットがライセンスを取得している状況を考慮